### PR TITLE
Remove unused textline orientation option in PaddleOCR instance

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,8 +12,7 @@ OCR = PaddleOCR(
     use_angle_cls=True,      # Enable rotation detection for photos taken at different angles
     use_gpu=False,
     lang="en",
-    use_doc_unwarping=True,  # Help with curved surfaces like bottles
-    use_textline_orientation=False  # Keep false as product text is typically horizontal
+    use_doc_unwarping=True   # Help with curved surfaces like bottles
 )
 
 app = FastAPI(title="PaddleOCR Server", version="1.0")


### PR DESCRIPTION
Eliminate the `use_textline_orientation` option as it is unnecessary for typical product text orientation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified OCR initialization; document unwarping remains enabled.
  * Adjusted configuration may change how text orientation is handled during OCR processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->