### PR TITLE
Remove unused GPU option from PaddleOCR instance

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from PIL import Image
 # Single OCR instance optimized for product labels and packaging
 OCR = PaddleOCR(
     use_angle_cls=True,      # Enable rotation detection for photos taken at different angles
-    use_gpu=False,
     lang="en",
     use_doc_unwarping=True   # Help with curved surfaces like bottles
 )


### PR DESCRIPTION
Eliminate the unused GPU option to streamline the PaddleOCR instance configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCR now automatically leverages GPU acceleration when available, improving processing speed and throughput.
  * No setup required; the system falls back to CPU when no compatible GPU is detected.
  * Users with supported GPUs may see reduced latency on larger images and batches.
  * Environments without GPUs behave as before, though resource usage may vary when GPU is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->